### PR TITLE
Deprecate the plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## v1.1.3
 
 - [#10 - Deprecate the plugin](https://github.com/alphagov/govuk-prototype-kit-task-list/pull/10)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- [#10 - Deprecate the plugin](https://github.com/alphagov/govuk-prototype-kit-task-list/pull/10)
+
 ## v1.1.2
 
 ### Fixes

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This plugin is no longer maintained.
 
-If you are using GOV.UK Prototype Kit version 5.0.0 or above, you should use the [task list component](https://design-system.service.gov.uk/components/task-list) from the GOV.UK Design System instead.
+If you are using govuk-frontend version 5.0.0 or above, you should use the [task list component](https://design-system.service.gov.uk/components/task-list) from the GOV.UK Design System instead.
 
 You can also use the task list template from the [common templates plugin](https://github.com/alphagov/govuk-prototype-kit-common-templates/).
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This plugin is no longer maintained.
 
-If you are using GOV.UK Prototype Kit version XX or above, you should use the [task list component](https://design-system.service.gov.uk/components/task-list) from the GOV.UK Design System instead.
+If you are using GOV.UK Prototype Kit version 5.0.0 or above, you should use the [task list component](https://design-system.service.gov.uk/components/task-list) from the GOV.UK Design System instead.
 
 You can also use the task list template from the [common templates plugin](https://github.com/alphagov/govuk-prototype-kit-common-templates/).
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 # Task list pattern - plugin for the GOV.UK Prototype Kit
 
-This plugin provides the code to use the GOV.UK Task list pattern in prototypes
+This plugin is no longer maintained.
+
+If you are using GOV.UK Prototype Kit version XX or above, you should use the [task list component](https://design-system.service.gov.uk/components/task-list) from the GOV.UK Design System instead.
+
+You can also use the task list template from the [common templates plugin](https://github.com/alphagov/govuk-prototype-kit-common-templates/).
+
+If you are using a previous version of the GOV.UK Prototype Kit, you can continue to use this plugin until you upgrade.
 
 For more information about the GOV.UK Prototype Kit:
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This plugin is no longer maintained.
 
-If you are using govuk-frontend version 5.0.0 or above, you should use the [task list component](https://design-system.service.gov.uk/components/task-list) from the GOV.UK Design System instead.
+If you are using GOV.UK Frontend version 5.0.0 or above, you should use the [task list component](https://design-system.service.gov.uk/components/task-list) from the GOV.UK Design System instead.
 
 You can also use the task list template from the [common templates plugin](https://github.com/alphagov/govuk-prototype-kit-common-templates/).
 

--- a/govuk-prototype-kit.config.json
+++ b/govuk-prototype-kit.config.json
@@ -1,6 +1,6 @@
 {
   "meta": {
-    "description": "This plugin provides the code to use the GOV.UK Task list pattern in prototypes",
+    "description": "This plugin is deprecated and should be uninstalled. Use the Task list template from ‘Common Templates’ instead",
     "urls": {
       "versionHistory": "https://github.com/alphagov/govuk-prototype-kit-task-list/blob/main/CHANGELOG.md"
     }

--- a/govuk-prototype-kit.config.json
+++ b/govuk-prototype-kit.config.json
@@ -1,6 +1,6 @@
 {
   "meta": {
-    "description": "This plugin is deprecated and should be uninstalled. Use the Task list template from ‘Common Templates’ instead",
+    "description": "This plugin is deprecated and Task list is now included in GOV.UK Frontend v5.0.0. Uninstall and use the latest ‘Common Templates’ plugin instead, unless GOV.UK Frontend v4 supported is needed.",
     "urls": {
       "versionHistory": "https://github.com/alphagov/govuk-prototype-kit-task-list/blob/main/CHANGELOG.md"
     }

--- a/govuk-prototype-kit.config.json
+++ b/govuk-prototype-kit.config.json
@@ -7,7 +7,8 @@
   },
   "pluginDependencies": [{
     "packageName": "govuk-frontend",
-    "minVersion": "3.12.0"
+    "minVersion": "3.12.0",
+    "maxVersion": "4.7.0"
   }],
   "sass": [
     "/sass/_task-list.scss"

--- a/govuk-prototype-kit.config.json
+++ b/govuk-prototype-kit.config.json
@@ -1,6 +1,6 @@
 {
   "meta": {
-    "description": "This plugin is deprecated and Task list is now included in GOV.UK Frontend v5.0.0. Uninstall and use the latest ‘Common Templates’ plugin instead, unless GOV.UK Frontend v4 supported is needed.",
+    "description": "This plugin is deprecated and Task list is now included in GOV.UK Frontend v5.0.0. Uninstall and use the latest ‘Common Templates’ plugin instead, unless GOV.UK Frontend v4 support is needed.",
     "urls": {
       "versionHistory": "https://github.com/alphagov/govuk-prototype-kit-task-list/blob/main/CHANGELOG.md"
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@govuk-prototype-kit/task-list",
-  "version": "1.1.3",
+  "version": "2.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@govuk-prototype-kit/task-list",
-      "version": "1.1.3",
+      "version": "2.0.0",
       "license": "MIT"
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@govuk-prototype-kit/task-list",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@govuk-prototype-kit/task-list",
-      "version": "1.1.2",
+      "version": "1.1.3",
       "license": "MIT"
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@govuk-prototype-kit/task-list",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "GOV.UK Task List Pattern for the GOV.UK Prototype Kit",
   "author": "GOV.UK Prototype team, UK Government Digital Service",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@govuk-prototype-kit/task-list",
-  "version": "1.1.3",
+  "version": "2.0.0",
   "description": "GOV.UK Task List Pattern for the GOV.UK Prototype Kit",
   "author": "GOV.UK Prototype team, UK Government Digital Service",
   "license": "MIT",


### PR DESCRIPTION
This deprecates the plugin, by making it clear that it is no longer needed once version 5+ of `govuk-frontend` has been released.

See also: 

* [adding the task list template to the common-templates plugin](https://github.com/alphagov/govuk-prototype-kit-common-templates/pull/26)
* [Decide what to do with the Prototype Kit Task List plugin](https://github.com/alphagov/govuk-design-system/issues/3150)

This shouldn't be merged until v5 of `govuk-frontend` has been released, and then the Prototype Kit updated.